### PR TITLE
fix: quita símbolo caret de archivos package.json

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,22 +11,22 @@
   },
   "dependencies": {
     "@legion/shared": "*",
-    "@prisma/client": "^6.4.1",
-    "bcrypt": "^6.0.0",
-    "cookie-parser": "^1.4.6",
-    "cors": "^2.8.5",
+    "@prisma/client": "6.4.1",
+    "bcrypt": "6.0.0",
+    "cookie-parser": "1.4.6",
+    "cors": "2.8.5",
     "discord.js": "13.17.1",
-    "express": "^4.19.2",
-    "express-rate-limit": "^7.4.0",
+    "express": "4.19.2",
+    "express-rate-limit": "7.4.0",
     "next": "16.1.6",
-    "socket.io": "^4.8.1",
-    "zod": "^3.23.8"
+    "socket.io": "4.8.1",
+    "zod": "3.23.8"
   },
   "devDependencies": {
-    "@types/bcrypt": "^5.0.2",
-    "@types/cookie-parser": "^1.4.7",
-    "@types/express": "^4.17.21",
-    "tsx": "^4.19.2",
-    "typescript": "^5.7.3"
+    "@types/bcrypt": "5.0.2",
+    "@types/cookie-parser": "1.4.7",
+    "@types/express": "4.17.21",
+    "tsx": "4.19.2",
+    "typescript": "5.7.3"
   }
 }

--- a/apps/bot/package.json
+++ b/apps/bot/package.json
@@ -11,12 +11,12 @@
   },
   "dependencies": {
     "@legion/shared": "*",
-    "discord.js": "^13.17.1",
+    "discord.js": "13.17.1",
     "next": "16.1.6",
-    "zod": "^3.23.8"
+    "zod": "3.23.8"
   },
   "devDependencies": {
-    "tsx": "^4.19.2",
-    "typescript": "^5.7.3"
+    "tsx": "4.19.2",
+    "typescript": "5.7.3"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,23 +10,23 @@
   },
   "dependencies": {
     "@legion/shared": "*",
-    "@radix-ui/react-slot": "^1.1.1",
-    "class-variance-authority": "^0.7.1",
-    "clsx": "^2.1.1",
-    "lucide-react": "^0.474.0",
-    "next": "^16.1.6",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "socket.io-client": "^4.8.1",
-    "tailwind-merge": "^2.5.2"
+    "@radix-ui/react-slot": "1.1.1",
+    "class-variance-authority": "0.7.1",
+    "clsx": "2.1.1",
+    "lucide-react": "0.474.0",
+    "next": "16.1.6",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "socket.io-client": "4.8.1",
+    "tailwind-merge": "2.5.2"
   },
   "devDependencies": {
-    "@types/node": "^22.10.2",
-    "@types/react": "^18.3.12",
-    "@types/react-dom": "^18.3.1",
-    "autoprefixer": "^10.4.20",
-    "postcss": "^8.4.49",
-    "tailwindcss": "^3.4.17",
-    "typescript": "^5.7.3"
+    "@types/node": "22.10.2",
+    "@types/react": "18.3.12",
+    "@types/react-dom": "18.3.1",
+    "autoprefixer": "10.4.20",
+    "postcss": "8.4.49",
+    "tailwindcss": "3.4.17",
+    "typescript": "5.7.3"
   }
 }


### PR DESCRIPTION
Esto permite que la versión precisa de las dependencias sea consistente y estricta. También permite evitar ciertos problemas de seguridad asociado al uso de versiones antiguas sin parchar en entornos preinstalados (uso de versiones en cache).